### PR TITLE
Fix white modals on answers.

### DIFF
--- a/quora-dark.css
+++ b/quora-dark.css
@@ -209,5 +209,15 @@
   .quote_hover_menu {
     /*[[hide-popup]]*/ display: none !important;
   }
+  
+  /*** Make the popup answer's background transparent black. ***/
+  .modal_overlay.feed_desktop_modal {
+   background: rgba(0,0,0,0.9);
+  }
+  
+  /*** Make the answer hover colour a dark black one. ***/
+  .toggle_modal_inline.inline_modal_highlight:hover {
+   background-color: #050505;
+  }
 
 }


### PR DESCRIPTION
Fixed the white modals when hovering on answers and when opening an answer (in a modal).

------

BEFORE:
![screenshot from 2016-06-26 17-33-11](https://cloud.githubusercontent.com/assets/10473142/16364019/9f520978-3bfa-11e6-95a7-35f1f78e7c77.png)
![screenshot from 2016-06-26 17-33-16](https://cloud.githubusercontent.com/assets/10473142/16364020/9f60b0ae-3bfa-11e6-9bcf-4df9b55ad665.png)

AFTER:
![screenshot from 2016-06-26 17-31-56](https://cloud.githubusercontent.com/assets/10473142/16364015/6dcc3efa-3bfa-11e6-80ce-7bed68ee6311.png)
![screenshot from 2016-06-26 17-32-04](https://cloud.githubusercontent.com/assets/10473142/16364014/6dcb67fa-3bfa-11e6-99ab-8ca1f106e84d.png)